### PR TITLE
Switch `solve()` to be `vmap`-d for asynchronous execution.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# NVIDIA Nsight profiling outputs 
+nsight*

--- a/basic_usage.ipynb
+++ b/basic_usage.ipynb
@@ -145,31 +145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "5138e842-a608-4d0c-8861-a14b8e95354d",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Open URL in browser: https://ui.perfetto.dev/#!/?url=http://127.0.0.1:9001/perfetto_trace.json.gz\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "127.0.0.1 - - [23/May/2023 19:42:26] code 404, message File not found\n",
-      "127.0.0.1 - - [23/May/2023 19:42:26] \"POST /status HTTP/1.1\" 404 -\n",
-      "127.0.0.1 - - [23/May/2023 19:42:26] \"GET /perfetto_trace.json.gz HTTP/1.1\" 200 -\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "with jax.profiler.trace(\"/tmp/jax-trace\", create_perfetto_link=True):\n",
+    "with jax.profiler.trace(\"/tmp/tensorboard\"):\n",
     "    prob, data, state = osqp.OSQPProblem.from_data(P, q, A, l, u)\n",
     "    sol_mine = jax.vmap(prob.solve)(data, state)"
    ]


### PR DESCRIPTION
What it says on the box + some other fixes. Switched QR -> LU factorization for the KKT matrix. Added some benchmarks -- we're much slower than (CPU-based, real) `osqp` and much faster than `jaxopt`. 