### PR TITLE
Add problem scaling + important primal_feas bugfix.

### DIFF
--- a/basic_usage.ipynb
+++ b/basic_usage.ipynb
@@ -1138,7 +1138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 105,
    "id": "f184fd6c-44c4-4f9a-8e5e-8c75052b96d9",
    "metadata": {
     "tags": []
@@ -1148,17 +1148,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 24 µs, sys: 0 ns, total: 24 µs\n",
-      "Wall time: 31.5 µs\n"
+      "CPU times: user 20 µs, sys: 2 µs, total: 22 µs\n",
+      "Wall time: 27.9 µs\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "0.024569"
+       "0.018224"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1333,17 +1333,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 98,
    "id": "bdbfea3f-9b4c-4e7d-82f3-242cd05db877",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4.3 ms, sys: 21 µs, total: 4.32 ms\n",
+      "Wall time: 4.3 ms\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "Array(0.00140209, dtype=float32)"
+       "(Array([[-0.31351]], dtype=float32), array([-0.31350996]))"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1357,13 +1365,13 @@
     "u = jnp.array([[0.88669298]])\n",
     "\n",
     "prob, data, state = osqp.OSQPProblem.from_data(P, q, A, l, u)\n",
-    "sol = jax.vmap(prob.solve)(data, state)\n",
+    "%time sol = jax.vmap(prob.solve)(data, state)\n",
     "sol[-1].z\n",
     "\n",
     "jax_obj = 0.5 * jnp.dot(sol[-1].x[0], P[0] @ sol[-1].x[0]) + jnp.dot(q[0], sol[-1].x[0])\n",
     "osqp_obj = 0.5 * np.dot(results[0].x, P[0] @ results[0].x) + np.dot(q[0], results[0].x)\n",
     "\n",
-    "jax_obj - osqp_obj"
+    "sol[-1].x, results[0].x"
    ]
   }
  ],


### PR DESCRIPTION
Implements problem scaling for OSQP (i.e., the modified Ruiz equilibriation in Algorithm 2). 

Also fixes an important bug where the primal infeasibility check is invalid when `state.dy` is exactly zero (which happens when constraints start + remain inactive).