### PR TITLE
Elementwise multiplication to handle unconstrained l/u bound

### DIFF
--- a/jaxosqp/osqp.py
+++ b/jaxosqp/osqp.py
@@ -172,8 +172,8 @@ class OSQPProblem:
             if P is not None: new_data.P = data.c * jnp.diag(data.D) @ P @ jnp.diag(data.D)
             if q is not None: new_data.q = data.c * jnp.diag(data.D) @ q
             if A is not None: new_data.A = jnp.diag(data.E) @ A @ jnp.diag(data.D)
-            if l is not None: new_data.l = jnp.diag(data.E) @ l
-            if u is not None: new_data.u = jnp.diag(data.E) @ u
+            if l is not None: new_data.l = data.E * l
+            if u is not None: new_data.u = data.E * u
             
         if rescale_data:
             new_data = self.scale_problem(new_data)
@@ -403,8 +403,8 @@ class OSQPProblem:
             P = data.c * jnp.diag(delta_d) @ data.P @ jnp.diag(delta_d)
             q = data.c * jnp.diag(delta_d) @ data.q
             A = jnp.diag(delta_e) @ data.A @ jnp.diag(delta_d)
-            l = jnp.diag(delta_e) @ data.l
-            u = jnp.diag(delta_e) @ data.u
+            l = delta_e * data.l
+            u = delta_e * data.u
 
             # Compute new cost scaling term.
             gamma = 1 / jnp.maximum(jnp.mean(utils.linf_norm(P, axis=0)), utils.linf_norm(q))

--- a/jaxosqp/osqp.py
+++ b/jaxosqp/osqp.py
@@ -112,6 +112,10 @@ class OSQPProblem:
         assert len(A.shape) == 2
         m, n = A.shape
 
+        # Ensure lower/upper bounds are 1D
+        assert len(l.shape) == 1
+        assert len(u.shape) == 1
+
         # Create OSQPProblem object.
         prob = cls(n, m, config)
         


### PR DESCRIPTION
This is to fix an issue where `jnp.inf` values in `l` or `u` result in `nan` values and failed solves
Note: there may be an edge case if the user inputs an `l` or `u` as a 2D column vector instead of a 1D flat array. The elementwise multiplication won't work right in that case. 
Are `l` and `u` guaranteed to be 1D? I believe they are in general but want to check
