### PR TITLE
Update constraint matrix scaling based on OSQP C implementation

### DIFF
--- a/jaxosqp/osqp.py
+++ b/jaxosqp/osqp.py
@@ -400,8 +400,12 @@ class OSQPProblem:
             ii, data = val
 
             # Compute delta terms by looking at l-inf norms of the "data matrix" M (32).
-            delta_d = 1 / jnp.sqrt(1e-8 + utils.linf_norm(utils.vcat(data.P, data.A), axis=0))
-            delta_e = 1 / jnp.sqrt(1e-8 + utils.linf_norm(data.A.T, axis=0))
+            PA_norms = utils.limit_scaling(
+                utils.linf_norm(utils.vcat(data.P, data.A), axis=0)
+            )
+            A_T_norms = utils.limit_scaling(utils.linf_norm(data.A.T, axis=0))
+            delta_d = 1 / jnp.sqrt(PA_norms)
+            delta_e = 1 / jnp.sqrt(A_T_norms)
 
             # Update problem data with new scaling. 
             P = data.c * jnp.diag(delta_d) @ data.P @ jnp.diag(delta_d)

--- a/jaxosqp/utils.py
+++ b/jaxosqp/utils.py
@@ -1,5 +1,9 @@
 import jax.numpy as jnp
 
+OSQP_MAX_SCALING = 1e4
+OSQP_MIN_SCALING = 1e-4
+
+
 def vcat(*args):
     return jnp.concatenate(args, axis=0)
 
@@ -8,3 +12,11 @@ def hcat(*args):
 
 def linf_norm(x, **args):
     return jnp.linalg.norm(x, ord=jnp.inf, **args)
+
+def limit_scaling(x):
+    """Limit the scaling factors within the bounds of the OSQP C implementation
+
+    Values below OSQP_MIN_SCALING are set to 1.0 while values above OSQP_MAX_SCALING are clipped
+    """
+    x = jnp.where(x < OSQP_MIN_SCALING, 1.0, x)
+    return jnp.where(x > OSQP_MAX_SCALING, OSQP_MAX_SCALING, x)


### PR DESCRIPTION
Fix for https://github.com/Caltech-AMBER/jaxosqp/issues/13

Note: OSQP also uses these scaling limits on the cost as well, but when I added this in, it totally changed the result for many of my problems. So, I left the scaling limits only on the constraint terms.